### PR TITLE
Suppress messages for readr 2.0.0 support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,4 +55,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
 # fgeo.tool (development version)
 
+* `read_vft()` and `read_taxa()` no longer throw needless messages (@jimhester
+#189).
+
 # fgeo.tool 1.2.6
 
-* Work in progress.
+* Maintenance release.
 
 # fgeo.tool 1.2.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 
 # fgeo.tool 1.2.6
 
-* Maintenance release.
+* Work in progress.
 
 # fgeo.tool 1.2.5
 

--- a/R/read_fgeo.R
+++ b/R/read_fgeo.R
@@ -2,10 +2,10 @@ read_fgeo <- function(col_types) {
   function(file, delim = NULL, na = c("", "NA", "NULL"), ...) {
     delim <- delim %||% guess_comma_or_tab(file, names(col_types))
 
-    # Most common warning is too noisy and distracts more than helps
-    dfm <- suppressWarnings(
+    # Most common warnings and messages are too noisy and distracts more than helps
+    dfm <- suppressMessages(suppressWarnings(
       read_delim_(delim, file = file, col_types = col_types, na = na, ...)
-    )
+    ))
 
     # if `file` has rownames, the `result` has more columns than needed
     result <- dfm[names(col_types)]

--- a/R/read_fgeo.R
+++ b/R/read_fgeo.R
@@ -2,12 +2,12 @@ read_fgeo <- function(col_types) {
   function(file, delim = NULL, na = c("", "NA", "NULL"), ...) {
     delim <- delim %||% guess_comma_or_tab(file, names(col_types))
 
-    # Most common warnings and messages are too noisy and distracts more than helps
+    # The point of this function is to handle rather than warn/inform issues
     dfm <- suppressMessages(suppressWarnings(
       read_delim_(delim, file = file, col_types = col_types, na = na, ...)
     ))
 
-    # if `file` has rownames, the `result` has more columns than needed
+    # If input has rownames, we end up with more columns than we need
     result <- dfm[names(col_types)]
     readr::type_convert(result, col_types = col_types)
   }

--- a/man/flag_if_group.Rd
+++ b/man/flag_if_group.Rd
@@ -16,7 +16,7 @@ detect_if_group(.data, name, predicate)
 
 \item{predicate}{A predicate function, e.g. \code{\link[=is_multiple]{is_multiple()}}.}
 
-\item{condition}{A condition function, e.g. \code{\link[rlang:inform]{rlang::inform()}} or
+\item{condition}{A condition function, e.g. \code{\link[rlang:abort]{rlang::inform()}} or
 \code{\link[base:stop]{base::stop()}}.}
 
 \item{msg}{String to customize the returned message.}

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -32,12 +32,12 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{dplyr}{\code{\link[dplyr]{add_count}}, \code{\link[dplyr]{arrange}}, \code{\link[dplyr]{count}}, \code{\link[dplyr]{filter}}, \code{\link[dplyr]{group_by}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{select}}, \code{\link[dplyr]{summarise}}, \code{\link[dplyr]{summarize}}, \code{\link[dplyr]{ungroup}}}
+  \item{dplyr}{\code{\link[dplyr:count]{add_count}}, \code{\link[dplyr]{arrange}}, \code{\link[dplyr]{count}}, \code{\link[dplyr]{filter}}, \code{\link[dplyr]{group_by}}, \code{\link[dplyr]{mutate}}, \code{\link[dplyr]{select}}, \code{\link[dplyr]{summarise}}, \code{\link[dplyr:summarise]{summarize}}, \code{\link[dplyr:group_by]{ungroup}}}
 
-  \item{rlang}{\code{\link[rlang]{\%||\%}}}
+  \item{rlang}{\code{\link[rlang:op-null-default]{\%||\%}}}
 
   \item{tibble}{\code{\link[tibble]{as_tibble}}, \code{\link[tibble]{tibble}}, \code{\link[tibble]{tribble}}, \code{\link[tibble]{tribble}}}
 
-  \item{tidyselect}{\code{\link[tidyselect]{contains}}, \code{\link[tidyselect]{ends_with}}, \code{\link[tidyselect]{everything}}, \code{\link[tidyselect]{last_col}}, \code{\link[tidyselect]{matches}}, \code{\link[tidyselect]{num_range}}, \code{\link[tidyselect]{one_of}}, \code{\link[tidyselect]{starts_with}}}
+  \item{tidyselect}{\code{\link[tidyselect:starts_with]{contains}}, \code{\link[tidyselect:starts_with]{ends_with}}, \code{\link[tidyselect]{everything}}, \code{\link[tidyselect:everything]{last_col}}, \code{\link[tidyselect:starts_with]{matches}}, \code{\link[tidyselect:starts_with]{num_range}}, \code{\link[tidyselect]{one_of}}, \code{\link[tidyselect]{starts_with}}}
 }}
 

--- a/man/type_ensure.Rd
+++ b/man/type_ensure.Rd
@@ -32,7 +32,7 @@ type_ensure(dfm, c("w", "x", "y"), "numeric")
 type_ensure(dfm, c("w", "x", "y", "z"), "character")
 }
 \seealso{
-\code{\link[purrr:modify_at]{purrr::modify_at()}}.
+\code{\link[purrr:modify]{purrr::modify_at()}}.
 
 Other functions to operate on column types: 
 \code{\link{type_vft}()}

--- a/man/type_vft.Rd
+++ b/man/type_vft.Rd
@@ -15,8 +15,8 @@ A list.
 \description{
 A common cause of problems is feeding functions with data which columns are
 not all of the expected type. The problem often begins when reading data from
-a text file with functions such as \code{\link[utils:read.csv]{utils::read.csv()}},
-\code{\link[utils:read.delim]{utils::read.delim()}}, and friends -- which commonly guess wrongly the column
+a text file with functions such as \code{\link[utils:read.table]{utils::read.csv()}},
+\code{\link[utils:read.table]{utils::read.delim()}}, and friends -- which commonly guess wrongly the column
 type that you more likely expect. These common offenders are strongly
 discouraged; instead consider using \code{readr::read_csv()}, \code{readr::read_tsv()},
 and friends, which guess column types correctly much more often than their

--- a/tests/testthat/test-read_fgeo.R
+++ b/tests/testthat/test-read_fgeo.R
@@ -7,14 +7,13 @@ test_that("read_vft fails gracefully if data has missing columns", {
   expect_error(read_vft(comma), "DBHID")
 })
 
-test_that("read_vft guesses tab or comma separated file", {
-  comma <- tempfile()
-  write.csv(fgeo.x::vft_4quad, comma)
-
-  expect_silent(
-    vft <- read_vft(comma)
-  )
-  expect_is(vft, "tbl")
+test_that("read_vft guesses tab or comma separated file, silently", {
+  file <- tempfile()
+  data <- fgeo.x::vft_4quad
+  write.csv(data, file)
+  
+  expect_silent(out <- read_vft(file))
+  expect_equal(out, data)
 })
 
 test_that("read_vft guesses tab or comma separated file", {


### PR DESCRIPTION
readr 2.0.0 can issue a message if name repair needs to be done for the
column names, as is the case when reading the data written by write.csv
in the test-read_fgeo.R

Suppressing messages as well as warnings resolves the test failure.

We plan to submit readr 2.0.0 to CRAN in 2-4 weeks. You will need to submit these changes before then to avoid failures on CRAN.